### PR TITLE
Not yet a pull request, see issue #7

### DIFF
--- a/gradle/android-mixed-java-kotlin-project/AndroidSample/build.gradle
+++ b/gradle/android-mixed-java-kotlin-project/AndroidSample/build.gradle
@@ -7,10 +7,10 @@ buildscript {
     }
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:0.1-SNAPSHOT'
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.1.0'
     }
 }
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 repositories {

--- a/gradle/android-mixed-java-kotlin-project/README.md
+++ b/gradle/android-mixed-java-kotlin-project/README.md
@@ -1,0 +1,12 @@
+
+Here is how to get started with the project `mixed-java-kotlin-hello-world`
+
+- set `sdk.dir` to your `$ANDROID_HOME` in `gradle/android-mixed-java-kotlin-project/local.properties`
+- Start IntelliJ or Android Studio and choose `Import Project` 
+- Choose directory `kotlin-examples/gradle/android-mixed-java-kotlin-project`
+- Choose `Import project from external model > Gradle`
+- Use customizable gradle wrapper > Finish
+
+
+
+


### PR DESCRIPTION
Add documentation, fix obsolete android build.grade
... but still fails to build the project

$ ./gradlew tasks --stacktrace

org.gradle.api.GradleScriptException: A problem occurred evaluating project ':AndroidSample'.
....
Caused by: java.lang.NoClassDefFoundError: org/codehaus/groovy/runtime/typehandling/ShortTypeHandling
	at com.android.build.gradle.BasePlugin.getLocalVersion(BasePlugin.groovy:491)
	at com.android.build.gradle.BasePlugin.<init>(BasePlugin.groovy:129)
	at com.android.build.gradle.AppPlugin.<init>(AppPlugin.groovy:40)
	at org.gradle.api.internal.DependencyInjectingInstantiator.newInstance(DependencyInjectingInstantiator.java:62)
	at org.gradle.api.internal.plugins.DefaultPluginRegistry.loadPlugin(DefaultPluginRegistry.java:67)