### PR TITLE
Fix android test source directory definition

### DIFF
--- a/gradle/android-junit-test/app/build.gradle
+++ b/gradle/android-junit-test/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
-        test.java.srcDirs += 'src/test/kotlin'
+        androidTest.java.srcDirs += 'src/test/kotlin'
     }
 
     testOptions {


### PR DESCRIPTION
Neither IDEA nor Studio recognize "test.java.srcDirs", but IDEA does recognize "androidTest.java.srcDirs".
It seems to follow this guide: http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Project-Structure
Executing "test" task also picks only "androidTest" property.