### PR TITLE
Workaround for https://youtrack.jetbrains.com/issue/KT-10421

### DIFF
--- a/gradle/android-junit-test/app/build.gradle
+++ b/gradle/android-junit-test/app/build.gradle
@@ -48,5 +48,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:1.9.5"
+    androidTestCompile 'junit:junit:4.12'
+    androidTestCompile "org.mockito:mockito-core:1.9.5"
 }
 


### PR DESCRIPTION
NB: once https://youtrack.jetbrains.com/issue/KT-10421 is fixed, `testCompile` dependencies can be removed from the sample.