### PR TITLE
Proper project setup in the IDE

### DIFF
--- a/gradle/android-junit-test/README.md
+++ b/gradle/android-junit-test/README.md
@@ -1,0 +1,6 @@
+
+Some tips to use this project in the IDE (Android Studio or IDEA):
+
+- Before opening android-junit-test/build.gradle as new project, make sure that android-junit-test/local.properties exists and contains a setting like:
+  sdk.dir=/path/to/android/sdk/dir/in/your/system
+- After opening the project check Build Variants tool window and make sure Test Artifact = Unit Tests.

--- a/gradle/android-junit-test/README.md
+++ b/gradle/android-junit-test/README.md
@@ -1,7 +1,5 @@
 
 Some tips to use this project in the IDE (Android Studio or IDEA):
 
-- Before opening android-junit-test/build.gradle as new project, make sure that android-junit-test/local.properties exists and contains a setting like:
-  sdk.dir=/path/to/android/sdk/dir/in/your/system
 - After opening the project check Build Variants tool window and make sure Test Artifact = Unit Tests.
 

--- a/gradle/android-junit-test/README.md
+++ b/gradle/android-junit-test/README.md
@@ -4,3 +4,4 @@ Some tips to use this project in the IDE (Android Studio or IDEA):
 - Before opening android-junit-test/build.gradle as new project, make sure that android-junit-test/local.properties exists and contains a setting like:
   sdk.dir=/path/to/android/sdk/dir/in/your/system
 - After opening the project check Build Variants tool window and make sure Test Artifact = Unit Tests.
+

--- a/gradle/android-junit-test/app/build.gradle
+++ b/gradle/android-junit-test/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
-        androidTest.java.srcDirs += 'src/test/kotlin'
+        test.java.srcDirs += 'src/test/kotlin'
     }
 
     testOptions {


### PR DESCRIPTION
Currently Android plugin (Studio) sets Test Artifact = Android Instrumentation Tests by default.
To make Kotlin support work consistently it should be "Unit Tests".