### PR TITLE
Add support for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+
+jdk:
+    - oraclejdk8
+    - oraclejdk7
+    - openjdk7
+    - openjdk6
+script:
+    - cd maven && mvn verify
+    - cd ../gradle/android-butterknife && ./gradlew test
+    - cd ../../gradle/android-dagger && ./gradlew test
+    - cd ../../gradle/android-dbflow && ./gradlew test
+    - cd ../../gradle/android-junit-test && ./gradlew test
+    - cd ../../gradle/android-mixed-java-kotlin-project && ./gradlew test
+    - cd ../../gradle/android-realm && ./gradlew test
+    - cd ../../gradle/dokka-gradle-example && ./gradlew test
+    - cd ../../gradle/hello-world && ./gradlew test
+    - cd ../../gradle/mixed-java-kotlin-hello-world && ./gradlew test


### PR DESCRIPTION
Adds a .travis.yml file that includes support for 4 of the JDK's available in TravisCI to verify that the examples do not have specific JDK requirements.

Needs to be fixed to download the Android SDK and install it before running the relevant tests. Not sure what the procedure is for the Android SDk and installing it on TravisCI as I haven't developed for Android before.

Also needs to be optimised to avoid downloading gradle multiple times.