### PR TITLE
Update gradle and kotlin versions for hello world and dokka examples

### DIFF
--- a/gradle/dokka-gradle-example/build.gradle
+++ b/gradle/dokka-gradle-example/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.0.3'
+    ext.kotlin_version = '1.1.4-3'
 
     repositories {
         mavenLocal()

--- a/gradle/dokka-gradle-example/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/dokka-gradle-example/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/gradle/hello-world/build.gradle
+++ b/gradle/hello-world/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.0'
+  ext.kotlin_version = '1.1.4-3'
   repositories {
     mavenCentral()
   }
@@ -26,5 +26,5 @@ dependencies {
 }
 
 task wrapper(type: Wrapper) {
-  gradleVersion = "2.7"
+  gradleVersion = "4.1"
 }

--- a/gradle/hello-world/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/hello-world/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/gradle/mixed-java-kotlin-hello-world/build.gradle
+++ b/gradle/mixed-java-kotlin-hello-world/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.0'
+  ext.kotlin_version = '1.1.4-3'
   repositories {
     mavenCentral()
   }
@@ -30,5 +30,5 @@ dependencies {
 test.testClassesDir = project.tasks.compileTestKotlin.destinationDir
 
 task wrapper(type: Wrapper) {
-  gradleVersion="2.7"
+  gradleVersion="4.1"
 }

--- a/gradle/mixed-java-kotlin-hello-world/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/mixed-java-kotlin-hello-world/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
I found that the Kotlin version and Gradle version were both somewhat old, so I bumped them. Builds and runs successfully on Ubuntu Linux 17.04 x64 and Windows 7 x64.