### PR TITLE
fix mocha installation error

### DIFF
--- a/gradle/js-tests/mocha/build.gradle
+++ b/gradle/js-tests/mocha/build.gradle
@@ -43,7 +43,7 @@ task installMocha(type: NpmTask) {
 }
 
 task runMocha(type: NodeTask, dependsOn: [compileTestKotlin2Js, populateNodeModules, installMocha]) {
-    script = file('node_modules/mocha/bin/mocha')
+    script = file('./node_modules/mocha/bin/mocha')
     args = [compileTestKotlin2Js.outputFile]
 }
 


### PR DESCRIPTION
Without `./`, it installs mocha and other npm packages to `~/node_modules`, not the project directory