### PR TITLE
New "servlet-web-applications-maven" example

### DIFF
--- a/tutorials/servlet-web-applications-maven/.gitignore
+++ b/tutorials/servlet-web-applications-maven/.gitignore
@@ -1,0 +1,2 @@
+target
+.idea

--- a/tutorials/servlet-web-applications-maven/ReadMe.md
+++ b/tutorials/servlet-web-applications-maven/ReadMe.md
@@ -1,0 +1,45 @@
+# Kotlin Servlet Web Application Example With Maven
+
+This example is a **maven** version of **servlet-web-applications** example built using gradle.
+
+Since this example illustrates the use of a REST endpoint, you will need to run this on a web application server.
+
+## Prerequisites to running the example
+
+ * download Maven directly from the [Apache Maven homepage](http://maven.apache.org/download.html)
+ * install and configure your system as described in [the installation section](http://maven.apache.org/download.html#Installation)
+
+## Folder Structure
+
+Sources
+
+    /src/main/kotlin
+
+Build/War File
+
+    /target/kotlin-test-servlets.war
+    
+    
+## Compiling/Building the example's war file
+
+If you have maven on your path, type:
+
+	mvn clean package
+	
+This will compile:
+ * src/main/kotlin/HomeController.kt and builds a war file named **kotling-test-servlets.war** into **/target** folder
+
+
+## Running the example's war file
+
+Once you compiled the sources with previous 'mvn clean package' command, you can see the 'war' file under '/target' folder. 
+
+Now copy the 'war' file and deploy to any web application server like Tomcat, Jetty etc.
+
+After the deployment is done successfully, open a browser and point to a url like this
+    
+    http://localhost:8080/kotlin-test-servlets/hello
+    
+You should see an output as below:
+
+    Hello, World!

--- a/tutorials/servlet-web-applications-maven/pom.xml
+++ b/tutorials/servlet-web-applications-maven/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jetbrains.kotlin.examples</groupId>
+    <artifactId>servlet-web-applications-maven</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <kotlin.version>1.0.3</kotlin.version>
+        <java.version>1.8</java.version>
+        <junit.version>4.12</junit.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>src/main/kotlin</sourceDir>
+                                <sourceDir>src/main/resources</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>src/test/kotlin</sourceDir>
+                                <sourceDir>src/test/resources</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <warName>kotlin-test-servlets</warName>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tutorials/servlet-web-applications-maven/src/main/kotlin/HomeController.kt
+++ b/tutorials/servlet-web-applications-maven/src/main/kotlin/HomeController.kt
@@ -1,0 +1,13 @@
+package org.jetbrains.kotlin.demo
+
+import javax.servlet.annotation.WebServlet
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@WebServlet(name = "Hello", value = "/hello")
+class HomeController : HttpServlet() {
+    override fun doGet(req: HttpServletRequest, res: HttpServletResponse) {
+        res.writer.write("Hello, World!")
+    }
+}


### PR DESCRIPTION
The "servlet-web-applications" example is a good starter for using REST endpoints with Kotlin but is built with gradle. Wanted to add an example to build the same example using **Maven**. This will be helpful for developers like me who do not have have gradle expertise.