### PR TITLE
JS Test Examples: Move from gradle plugin com.moowork.node to de.solugo.gradle.nodejs

### DIFF
--- a/gradle/js-tests/.gitignore
+++ b/gradle/js-tests/.gitignore
@@ -3,3 +3,4 @@ build
 .idea
 *.iml
 node_modules
+package-lock.json

--- a/gradle/js-tests/frontend-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/js-tests/frontend-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/gradle/js-tests/jasmine/build.gradle
+++ b/gradle/js-tests/jasmine/build.gradle
@@ -4,12 +4,12 @@ buildscript {
     }
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.20'
-        classpath 'com.moowork.gradle:gradle-node-plugin:1.2.0'
+        classpath 'gradle.plugin.de.solugo.gradle:gradle-nodejs-plugin:0.2.1'
     }
 }
 
 apply plugin: 'kotlin2js'
-apply plugin: 'com.moowork.node'
+apply plugin: 'de.solugo.gradle.nodejs'
 
 repositories {
     jcenter()
@@ -34,17 +34,10 @@ task populateNodeModules(type: Copy, dependsOn: compileKotlin2Js) {
    into "${buildDir}/node_modules"
 }
 
-node { 
-  download = true
-}
-
-task installJasmine(type: NpmTask) {
-    args = ['install', 'jasmine']
-}
-
-task runJasmine(type: NodeTask, dependsOn: [compileTestKotlin2Js, populateNodeModules, installJasmine]) {
-    script = file('node_modules/jasmine/bin/jasmine.js')
-    args = [compileTestKotlin2Js.outputFile]
+task runJasmine(type: NodeJsTask, dependsOn: [compileTestKotlin2Js, populateNodeModules]) {
+    require = ["jasmine"]
+    executable = "node_modules/jasmine/bin/jasmine.js"
+    args = [projectDir.toPath().relativize(file(compileTestKotlin2Js.outputFile).toPath())]
 }
 
 test.dependsOn runJasmine

--- a/gradle/js-tests/jasmine/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/js-tests/jasmine/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/gradle/js-tests/jest/build.gradle
+++ b/gradle/js-tests/jest/build.gradle
@@ -4,12 +4,12 @@ buildscript {
     }
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.20'
-        classpath 'com.moowork.gradle:gradle-node-plugin:1.2.0'
+        classpath 'gradle.plugin.de.solugo.gradle:gradle-nodejs-plugin:0.2.1'
     }
 }
 
 apply plugin: 'kotlin2js'
-apply plugin: 'com.moowork.node'
+apply plugin: 'de.solugo.gradle.nodejs'
 
 repositories {
     jcenter()
@@ -34,17 +34,10 @@ task populateNodeModules(type: Copy, dependsOn: compileKotlin2Js) {
    into "${buildDir}/node_modules"
 }
 
-node { 
-  download = true
-}
-
-task installJest(type: NpmTask) {
-    args = ['install', 'jest']
-}
-
-task runJest(type: NodeTask, dependsOn: [compileTestKotlin2Js, populateNodeModules, installJest]) {
-    script = file('node_modules/jest/bin/jest.js')
-    args = [projectDir.toURI().relativize(compileTestKotlin2Js.outputFile.toURI())]
+task runJest(type: NodeJsTask, dependsOn: [compileTestKotlin2Js, populateNodeModules]) {
+    require = ["jest"]
+    executable = "node_modules/jest/bin/jest.js"
+    args = [projectDir.toPath().relativize(file(compileTestKotlin2Js.outputFile).toPath())]
 }
 
 test.dependsOn runJest

--- a/gradle/js-tests/jest/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/js-tests/jest/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/gradle/js-tests/jest/package.json
+++ b/gradle/js-tests/jest/package.json
@@ -3,6 +3,9 @@
     "test": "./gradlew test"
   },
   "jest": {
-     "testRegex": "_test\\.js$"
+    "testRegex": "_test\\.js$"
+  },
+  "dependencies": {
+    "jest": "^23.0.1"
   }
 }

--- a/gradle/js-tests/karma/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/js-tests/karma/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/gradle/js-tests/mocha/build.gradle
+++ b/gradle/js-tests/mocha/build.gradle
@@ -4,12 +4,12 @@ buildscript {
     }
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.20'
-        classpath 'com.moowork.gradle:gradle-node-plugin:1.2.0'
+        classpath 'gradle.plugin.de.solugo.gradle:gradle-nodejs-plugin:0.2.1'
     }
 }
 
 apply plugin: 'kotlin2js'
-apply plugin: 'com.moowork.node'
+apply plugin: 'de.solugo.gradle.nodejs'
 
 repositories {
     jcenter()
@@ -34,17 +34,10 @@ task populateNodeModules(type: Copy, dependsOn: compileKotlin2Js) {
    into "${buildDir}/node_modules"
 }
 
-node { 
-  download = true
-}
-
-task installMocha(type: NpmTask) {
-    args = ['install', 'mocha']
-}
-
-task runMocha(type: NodeTask, dependsOn: [compileTestKotlin2Js, populateNodeModules, installMocha]) {
-    script = file('node_modules/mocha/bin/mocha')
-    args = [compileTestKotlin2Js.outputFile]
+task runMocha(type: NodeJsTask, dependsOn: [compileTestKotlin2Js, populateNodeModules]) {
+    require = ["mocha"]
+    executable = "node_modules/mocha/bin/mocha"
+    args = [projectDir.toPath().relativize(file(compileTestKotlin2Js.outputFile).toPath())]
 }
 
 test.dependsOn runMocha

--- a/gradle/js-tests/mocha/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/js-tests/mocha/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/gradle/js-tests/qunit/build.gradle
+++ b/gradle/js-tests/qunit/build.gradle
@@ -4,12 +4,12 @@ buildscript {
     }
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.20'
-        classpath 'com.moowork.gradle:gradle-node-plugin:1.2.0'
+        classpath 'gradle.plugin.de.solugo.gradle:gradle-nodejs-plugin:0.2.1'
     }
 }
 
 apply plugin: 'kotlin2js'
-apply plugin: 'com.moowork.node'
+apply plugin: 'de.solugo.gradle.nodejs'
 
 repositories {
     jcenter()
@@ -34,16 +34,9 @@ task populateNodeModules(type: Copy, dependsOn: compileKotlin2Js) {
    into "${buildDir}/node_modules"
 }
 
-node { 
-  download = true
-}
-
-task installQunit(type: NpmTask) {
-    args = ['install', 'qunitjs']
-}
-
-task runQunit(type: NodeTask, dependsOn: [compileTestKotlin2Js, populateNodeModules, installQunit]) {
-    script = file('node_modules/qunitjs/bin/qunit')
+task runQunit(type: NodeJsTask, dependsOn: [compileTestKotlin2Js, populateNodeModules]) {
+    require = ["qunit"]
+    executable = "node_modules/qunit/bin/qunit"
     args = [projectDir.toPath().relativize(file(compileTestKotlin2Js.outputFile).toPath())]
 }
 

--- a/gradle/js-tests/qunit/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/js-tests/qunit/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip

--- a/gradle/js-tests/tape/build.gradle
+++ b/gradle/js-tests/tape/build.gradle
@@ -4,12 +4,12 @@ buildscript {
     }
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.20'
-        classpath 'com.moowork.gradle:gradle-node-plugin:1.2.0'
+        classpath 'gradle.plugin.de.solugo.gradle:gradle-nodejs-plugin:0.2.1'
     }
 }
 
 apply plugin: 'kotlin2js'
-apply plugin: 'com.moowork.node'
+apply plugin: 'de.solugo.gradle.nodejs'
 
 repositories {
     jcenter()
@@ -24,25 +24,20 @@ dependencies {
     kotlinOptions.moduleKind = "commonjs"
 }
 
-task populateNodeModules(type: Copy) {
+task populateNodeModules(type: Copy, dependsOn: compileKotlin2Js) {
    from compileKotlin2Js.destinationDir
 
-   configurations.testCompile.each { from zipTree(it.absolutePath) }
-   include '*.js'
+   configurations.testCompile.each {
+       from zipTree(it.absolutePath).matching { include '*.js' }
+   }
+
    into "${buildDir}/node_modules"
 }
 
-node { 
-  download = true
-}
-
-task installTape(type: NpmTask) {
-    args = ['install', 'tape']
-}
-
-task testTape(type: NodeTask, dependsOn: [compileTestKotlin2Js, populateNodeModules, installTape]) {
-  script = file('node_modules/tape/bin/tape')
-  args = ['tape-plugin.js', compileTestKotlin2Js.outputFile]
+task("testTape", type: NodeJsTask, dependsOn: [compileTestKotlin2Js, populateNodeModules]) {
+    require = ["tape"]
+    executable = "node_modules/tape/bin/tape"
+    args = ['tape-plugin.js', projectDir.toPath().relativize(file(compileTestKotlin2Js.outputFile).toPath())]
 }
 
 test.dependsOn testTape

--- a/gradle/js-tests/tape/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/js-tests/tape/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip


### PR DESCRIPTION
The `com.moowork.node` gradle plugin is [incompatible with Gradle 4.6 when `GRADLE_METADATA` is used](https://github.com/srs/gradle-node-plugin/pull/296). Which makes it fail when used with plugin that uses this features, [such as Kotlin/Native `konan` gradle plugin](https://github.com/JetBrains/kotlin-native/issues/1612).

Therefore, when creating a multi-platform project, using the provided examples do not work. 

In this PR, I propose to replace this gradle plugin with the `de.solugo.gradle.nodejs` plugin, which works as expected on gradle 4.6+.

This will provide examples that work in pure Kotlin/JS projects, but also in Kotlin/Everywhere projects.

Note that the `karma` example is untouched and is the only one that will continue to fail: the example uses the `com.craigburke.karma` gradle plugin, which itself depends on `com.moowork.node`.

This PR fixes the `jasmine`, `jest`, `mocha`, `qunit` and `jest` examples. 